### PR TITLE
Version/1.2.2

### DIFF
--- a/SaxWeather/SaxWeatherWidget/SaxWeatherWidget.swift
+++ b/SaxWeather/SaxWeatherWidget/SaxWeatherWidget.swift
@@ -133,6 +133,12 @@ struct SaxWeatherWidgetEntryView : View {
             mediumWidgetView
         case .systemLarge:
             largeWidgetView
+        case .accessoryCircular:
+            accessoryCircularView
+        case .accessoryRectangular:
+            accessoryRectangularView
+        case .accessoryInline:
+            accessoryInlineView
         default:
             smallWidgetView
         }
@@ -485,6 +491,99 @@ struct SaxWeatherWidgetEntryView : View {
         .padding(18)
     }
     
+    // MARK: - Lock Screen Widgets (Accessory)
+    
+    private var accessoryCircularView: some View {
+        VStack(spacing: 0) {
+            if let temp = entry.temperature {
+                Text(weatherSymbol(for: entry.condition))
+                    .font(.system(size: 14))
+                Text("\(String(format: "%.0f", temp))°")
+                    .font(.system(size: 20, weight: .heavy))
+                    .minimumScaleFactor(0.7)
+                if let high = entry.high, let low = entry.low {
+                    HStack(spacing: 2) {
+                        Text("\(String(format: "%.0f", high))°")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                        Text("/")
+                            .font(.system(size: 8, weight: .regular))
+                            .foregroundStyle(.tertiary)
+                        Text("\(String(format: "%.0f", low))°")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                }
+            } else {
+                Image(systemName: "cloud.fill")
+                    .font(.system(size: 20))
+            }
+        }
+    }
+    
+    private var accessoryRectangularView: some View {
+        HStack(spacing: 8) {
+            if let temp = entry.temperature {
+                Text(weatherSymbol(for: entry.condition))
+                    .font(.system(size: 28))
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(String(format: "%.0f", temp))°")
+                        .font(.system(size: 24, weight: .heavy))
+                    
+                    if let high = entry.high, let low = entry.low {
+                        HStack(spacing: 4) {
+                            HStack(spacing: 1) {
+                                Text("↑")
+                                    .font(.system(size: 10, weight: .medium))
+                                    .foregroundStyle(.red.opacity(0.9))
+                                Text("\(String(format: "%.0f", high))°")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                            HStack(spacing: 1) {
+                                Text("↓")
+                                    .font(.system(size: 10, weight: .medium))
+                                    .foregroundStyle(.blue.opacity(0.9))
+                                Text("\(String(format: "%.0f", low))°")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                        }
+                    } else if let condition = entry.condition {
+                        Text(condition)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                
+                Spacer()
+            } else {
+                Text("No Data")
+                    .font(.caption2)
+            }
+        }
+    }
+    
+    private var accessoryInlineView: some View {
+        Group {
+            if let temp = entry.temperature {
+                HStack(spacing: 4) {
+                    Text(weatherSymbol(for: entry.condition))
+                    Text("\(String(format: "%.0f", temp))°")
+                    if let high = entry.high, let low = entry.low {
+                        Text("H:\(String(format: "%.0f", high))° L:\(String(format: "%.0f", low))°")
+                    } else if let condition = entry.condition {
+                        Text(condition)
+                    }
+                }
+            } else {
+                Text("No Weather Data")
+            }
+        }
+    }
+    
     private func weatherSymbol(for condition: String?) -> String {
         guard let condition = condition?.lowercased() else { return "☀️" }
         
@@ -598,7 +697,14 @@ struct SaxWeatherWidget: Widget {
         }
         .configurationDisplayName("SaxWeather")
         .description("Shows the latest weather from SaxWeather app.")
-        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .supportedFamilies([
+            .systemSmall,
+            .systemMedium,
+            .systemLarge,
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline
+        ])
     }
 }
 
@@ -622,4 +728,25 @@ struct SaxWeatherWidget: Widget {
 } timeline: {
     WeatherWidgetEntry(date: .now, temperature: 28.1, condition: "Sunny", high: 31.5, low: 23.8, humidity: 62.0, feelsLike: 29.5, windSpeed: 15.0, uvIndex: 8, pressure: 1015.0)
     WeatherWidgetEntry(date: .now, temperature: 5.2, condition: "Snowy", high: 7.1, low: 2.3, humidity: 92.0, feelsLike: 2.8, windSpeed: 35.5, uvIndex: 1, pressure: 998.0)
+}
+
+#Preview(as: .accessoryCircular) {
+    SaxWeatherWidget()
+} timeline: {
+    WeatherWidgetEntry(date: .now, temperature: 28.1, condition: "Sunny", high: 31.5, low: 23.8, humidity: 62.0, feelsLike: 29.5, windSpeed: 15.0, uvIndex: 8, pressure: 1015.0)
+    WeatherWidgetEntry(date: .now, temperature: -3.7, condition: "Snowy", high: -1.2, low: -6.5, humidity: 92.0, feelsLike: -8.2, windSpeed: 32.0, uvIndex: 1, pressure: 995.0)
+}
+
+#Preview(as: .accessoryRectangular) {
+    SaxWeatherWidget()
+} timeline: {
+    WeatherWidgetEntry(date: .now, temperature: 28.1, condition: "Sunny", high: 31.5, low: 23.8, humidity: 62.0, feelsLike: 29.5, windSpeed: 15.0, uvIndex: 8, pressure: 1015.0)
+    WeatherWidgetEntry(date: .now, temperature: 15.6, condition: "Rainy", high: 17.8, low: 12.4, humidity: 88.0, feelsLike: 14.2, windSpeed: 25.0, uvIndex: 2, pressure: 1005.0)
+}
+
+#Preview(as: .accessoryInline) {
+    SaxWeatherWidget()
+} timeline: {
+    WeatherWidgetEntry(date: .now, temperature: 28.1, condition: "Sunny", high: 31.5, low: 23.8, humidity: 62.0, feelsLike: 29.5, windSpeed: 15.0, uvIndex: 8, pressure: 1015.0)
+    WeatherWidgetEntry(date: .now, temperature: 15.6, condition: "Rainy", high: 17.8, low: 12.4, humidity: 88.0, feelsLike: 14.2, windSpeed: 25.0, uvIndex: 2, pressure: 1005.0)
 }

--- a/SaxWeather/SaxWeatherWidgets/SaxWeatherWidgets.swift
+++ b/SaxWeather/SaxWeatherWidgets/SaxWeatherWidgets.swift
@@ -156,57 +156,74 @@ struct SaxWeatherWidgetsEntryView : View {
     private var accessoryWidgetView: some View {
         switch widgetFamily {
         case .accessoryCircular:
-            ZStack {
-                AccessoryWidgetBackground()
-                VStack(spacing: -2) {
-                    if let temp = entry.temperature {
-                        Text(weatherSymbol(for: entry.condition))
-                            .font(.system(size: 14))
-                        // Match main app temperature style
-                        Text("\(String(format: "%.1f", temp))°")
-                            .font(.system(size: 18, weight: .heavy))
-                            .minimumScaleFactor(0.7)
-                    } else {
-                        Image(systemName: "cloud.fill")
-                            .font(.system(size: 20))
+            VStack(spacing: 0) {
+                if let temp = entry.temperature {
+                    Text(weatherSymbol(for: entry.condition))
+                        .font(.system(size: 14))
+                    // Match main app temperature style
+                    Text("\(String(format: "%.0f", temp))°")
+                        .font(.system(size: 20, weight: .heavy))
+                        .minimumScaleFactor(0.7)
+                    // Add compact high/low display
+                    if let high = entry.high, let low = entry.low {
+                        HStack(spacing: 2) {
+                            Text("\(String(format: "%.0f", high))°")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                            Text("/")
+                                .font(.system(size: 8, weight: .regular))
+                                .foregroundStyle(.tertiary)
+                            Text("\(String(format: "%.0f", low))°")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
                     }
+                } else {
+                    Image(systemName: "cloud.fill")
+                        .font(.system(size: 20))
                 }
             }
             
         case .accessoryRectangular:
             HStack(spacing: 8) {
-                if let temp = entry.temperature, let condition = entry.condition {
+                if let temp = entry.temperature {
                     Text(weatherSymbol(for: entry.condition))
-                        .font(.system(size: 26))
+                        .font(.system(size: 28))
                     
-                    VStack(alignment: .leading, spacing: 1) {
-                        // Match main app temperature style
-                        Text("\(String(format: "%.1f", temp))°")
-                            .font(.system(size: 22, weight: .heavy))
-                        Text(condition)
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 2) {
+                        // Match main app temperature style - current temp
+                        Text("\(String(format: "%.0f", temp))°")
+                            .font(.system(size: 24, weight: .heavy))
+                        
+                        // Show high/low on second line
+                        if let high = entry.high, let low = entry.low {
+                            HStack(spacing: 4) {
+                                HStack(spacing: 1) {
+                                    Text("↑")
+                                        .font(.system(size: 10, weight: .medium))
+                                        .foregroundStyle(.red.opacity(0.9))
+                                    Text("\(String(format: "%.0f", high))°")
+                                        .font(.system(size: 12, weight: .semibold))
+                                }
+                                HStack(spacing: 1) {
+                                    Text("↓")
+                                        .font(.system(size: 10, weight: .medium))
+                                        .foregroundStyle(.blue.opacity(0.9))
+                                    Text("\(String(format: "%.0f", low))°")
+                                        .font(.system(size: 12, weight: .semibold))
+                                }
+                            }
+                        } else if let condition = entry.condition {
+                            Text(condition)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
                     }
                     
                     Spacer()
-                    
-                    if let high = entry.high, let low = entry.low {
-                        VStack(alignment: .trailing, spacing: 2) {
-                            HStack(spacing: 2) {
-                                Image(systemName: "arrow.up")
-                                    .font(.system(size: 8))
-                                Text("H:\(String(format: "%.1f", high))°")
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                            HStack(spacing: 2) {
-                                Image(systemName: "arrow.down")
-                                    .font(.system(size: 8))
-                                Text("L:\(String(format: "%.1f", low))°")
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                        }
-                    }
                 } else {
                     Text("No Data")
                         .font(.caption2)
@@ -217,8 +234,10 @@ struct SaxWeatherWidgetsEntryView : View {
             if let temp = entry.temperature {
                 HStack(spacing: 4) {
                     Text(weatherSymbol(for: entry.condition))
-                    Text("\(String(format: "%.1f", temp))°")
-                    if let condition = entry.condition {
+                    Text("\(String(format: "%.0f", temp))°")
+                    if let high = entry.high, let low = entry.low {
+                        Text("H:\(String(format: "%.0f", high))° L:\(String(format: "%.0f", low))°")
+                    } else if let condition = entry.condition {
                         Text(condition)
                     }
                 }
@@ -340,6 +359,13 @@ struct SaxWeatherWidgets: Widget {
 }
 
 #Preview(as: .accessoryRectangular) {
+    SaxWeatherWidgets()
+} timeline: {
+    WeatherEntry(date: .now, temperature: 28.1, condition: "Sunny", high: 31.5, low: 23.8)
+    WeatherEntry(date: .now, temperature: 15.6, condition: "Rainy", high: 17.8, low: 12.4)
+}
+
+#Preview(as: .accessoryInline) {
     SaxWeatherWidgets()
 } timeline: {
     WeatherEntry(date: .now, temperature: 28.1, condition: "Sunny", high: 31.5, low: 23.8)


### PR DESCRIPTION
This pull request adds and refines support for lock screen widget families (accessoryCircular, accessoryRectangular, and accessoryInline) in both the main `SaxWeatherWidget` and the `SaxWeatherWidgets` extension, ensuring consistent weather display across all widget types. It also updates widget previews for these new families and standardizes the display format for temperature and high/low values.

**Lock Screen Widget Support and UI Consistency**

* Added support for `.accessoryCircular`, `.accessoryRectangular`, and `.accessoryInline` widget families in `SaxWeatherWidget`, including new view implementations for each family to display current temperature, high/low, and condition in a compact format. [[1]](diffhunk://#diff-178b779e2f77e056edc276e0533be1d309a3a5742287aeacc69666fdf5209b53R136-R141) [[2]](diffhunk://#diff-178b779e2f77e056edc276e0533be1d309a3a5742287aeacc69666fdf5209b53R494-R586) [[3]](diffhunk://#diff-178b779e2f77e056edc276e0533be1d309a3a5742287aeacc69666fdf5209b53L601-R707)
* Updated the `supportedFamilies` property in `SaxWeatherWidget` to include the new accessory families, enabling these widgets on the lock screen.

**Widget Preview Enhancements**

* Added SwiftUI previews for the new accessory widget families in both `SaxWeatherWidget` and `SaxWeatherWidgets` to facilitate development and visual testing. [[1]](diffhunk://#diff-178b779e2f77e056edc276e0533be1d309a3a5742287aeacc69666fdf5209b53R732-R752) [[2]](diffhunk://#diff-1c94719dffd325f48042afa30a69805e6a11ac3a2f47dac231e765a6f03d7a87R367-R373)

**UI and Formatting Improvements**

* Standardized temperature formatting to display as integers (no decimal places) and improved the high/low display for all accessory widget types in both main and extension widgets, ensuring consistency and clarity. [[1]](diffhunk://#diff-1c94719dffd325f48042afa30a69805e6a11ac3a2f47dac231e765a6f03d7a87L159-L209) [[2]](diffhunk://#diff-1c94719dffd325f48042afa30a69805e6a11ac3a2f47dac231e765a6f03d7a87L220-R240)
* Refined the layout and font sizes for accessory widget views for better readability and a more polished appearance. [[1]](diffhunk://#diff-1c94719dffd325f48042afa30a69805e6a11ac3a2f47dac231e765a6f03d7a87L159-L209) [[2]](diffhunk://#diff-1c94719dffd325f48042afa30a69805e6a11ac3a2f47dac231e765a6f03d7a87L220-R240)